### PR TITLE
Release v0.4.4

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Liquidswap"
-version = "0.4.1"
+version = "0.4.4"
 upgrade_policy = "immutable"
 
 [addresses]
@@ -30,13 +30,13 @@ local = "./liquidswap_init/"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "a2a3bf79b68823287f962bded2abfaefc688e71c"
+rev = "main"
 subdir = "aptos-move/framework/aptos-framework"
 
 [dependencies.UQ64x64]
 git = "https://github.com/pontem-network/UQ64x64.git"
-rev = "v0.3.7"
+rev = "v0.3.8"
 
 [dependencies.U256]
 git = "https://github.com/pontem-network/U256.git"
-rev = "v0.3.8"
+rev = "v0.3.9"

--- a/liquidswap_init/Move.toml
+++ b/liquidswap_init/Move.toml
@@ -8,5 +8,5 @@ liquidswap = "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "a2a3bf79b68823287f962bded2abfaefc688e71c"
+rev = "main"
 subdir = "aptos-move/framework/aptos-framework"

--- a/liquidswap_lp/Move.toml
+++ b/liquidswap_lp/Move.toml
@@ -8,5 +8,5 @@ liquidswap_lp = "0x05a97986a9d031c4567e15b797be516910cfcb4156312482efc6a19c0a30c
 
 [dev-dependencies.MoveStdlib]
 git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "a2a3bf79b68823287f962bded2abfaefc688e71c"
+rev = "main"
 subdir = "aptos-move/framework/move-stdlib"


### PR DESCRIPTION
We stick to `main` branch of aptos dependencies.