### PR TITLE
Added Coin Registration into Swap Functions

### DIFF
--- a/liquidswap_router_v2/sources/scripts_v2.move
+++ b/liquidswap_router_v2/sources/scripts_v2.move
@@ -115,7 +115,12 @@ module liquidswap::scripts_v2 {
         );
 
         let account_addr = signer::address_of(account);
-        coin::deposit(account_addr, coin_y);
+
+        // register coin if not registered
+        if (!coin::is_account_registered<Y>(account_addr)) {
+            coin::register<Y>(account);
+        };
+        coin::deposit<Y>(account_addr, coin_y);
     }
 
     /// Swap maximum coin `X` for exact coin `Y`.
@@ -134,8 +139,14 @@ module liquidswap::scripts_v2 {
         );
 
         let account_addr = signer::address_of(account);
-        coin::deposit(account_addr, coin_x);
-        coin::deposit(account_addr, coin_y);
+        
+        // register coin if not registered
+        if (!coin::is_account_registered<Y>(account_addr)) {
+            coin::register<Y>(account);
+        };
+        //
+        coin::deposit<X>(account_addr, coin_x);
+        coin::deposit<Y>(account_addr, coin_y);
     }
 
     /// Swap `coin_in` of X for a `coin_out` of Y.
@@ -152,6 +163,11 @@ module liquidswap::scripts_v2 {
         let coin_y = router_v2::swap_coin_for_coin_unchecked<X, Y, Curve>(coin_x, coin_out);
 
         let account_addr = signer::address_of(account);
-        coin::deposit(account_addr, coin_y);
+
+        // register coin if not registered
+        if (!coin::is_account_registered<Y>(account_addr)) {
+            coin::register<Y>(account);
+        };
+        coin::deposit<Y>(account_addr, coin_y);
     }
 }

--- a/liquidswap_router_v2/tests/scripts_v2_tests.move
+++ b/liquidswap_router_v2/tests/scripts_v2_tests.move
@@ -151,6 +151,27 @@ module liquidswap::scripts_v2_tests {
         assert!(coin::balance<USDT>(lp_owner_addr) == 907, 2);
     }
 
+    // test swap with unregistered target coins
+    #[test]
+    public entry fun test_swap_exact_btc_for_usdt_unregistered() {
+        let (coin_admin, lp_owner) = register_pool_with_existing_liquidity(101, 10100);
+
+        let btc_coins_to_swap = test_coins::mint<BTC>(&coin_admin, 10);
+        coin::register<BTC>(&lp_owner);
+
+        let lp_owner_addr = signer::address_of(&lp_owner);
+        coin::deposit(lp_owner_addr, btc_coins_to_swap);
+
+        scripts_v2::swap<BTC, USDT, Uncorrelated>(
+            &lp_owner,
+            10,
+            900,
+        );
+
+        assert!(coin::balance<BTC>(lp_owner_addr) == 0, 1);
+        assert!(coin::balance<USDT>(lp_owner_addr) == 907, 2);
+    }
+
     #[test]
     public entry fun test_swap_btc_for_exact_usdt() {
         let (coin_admin, lp_owner) = register_pool_with_existing_liquidity(101, 10100);
@@ -158,6 +179,26 @@ module liquidswap::scripts_v2_tests {
         let btc_coins_to_swap = test_coins::mint<BTC>(&coin_admin, 10);
         coin::register<BTC>(&lp_owner);
         coin::register<USDT>(&lp_owner);
+
+        let lp_owner_addr = signer::address_of(&lp_owner);
+        coin::deposit(lp_owner_addr, btc_coins_to_swap);
+
+        scripts_v2::swap_into<BTC, USDT, Uncorrelated>(
+            &lp_owner,
+            10,
+            700,
+        );
+
+        assert!(coin::balance<BTC>(lp_owner_addr) == 2, 1);
+        assert!(coin::balance<USDT>(lp_owner_addr) == 700, 2);
+    }
+
+    #[test]
+    public entry fun test_swap_btc_for_exact_usdt_unregistered() {
+        let (coin_admin, lp_owner) = register_pool_with_existing_liquidity(101, 10100);
+
+        let btc_coins_to_swap = test_coins::mint<BTC>(&coin_admin, 10);
+        coin::register<BTC>(&lp_owner);
 
         let lp_owner_addr = signer::address_of(&lp_owner);
         coin::deposit(lp_owner_addr, btc_coins_to_swap);
@@ -193,7 +234,28 @@ module liquidswap::scripts_v2_tests {
         assert!(coin::balance<USDT>(lp_owner_addr) == 907, 2);
 
     }
+    
+    #[test]
+    public entry fun test_unchecked_swap_common_unregistered() {
+        let (coin_admin, lp_owner) = register_pool_with_existing_liquidity(101, 10100);
 
+        let btc_coins_to_swap = test_coins::mint<BTC>(&coin_admin, 10);
+        coin::register<BTC>(&lp_owner);
+
+        let lp_owner_addr = signer::address_of(&lp_owner);
+        coin::deposit(lp_owner_addr, btc_coins_to_swap);
+
+        scripts_v2::swap_unchecked<BTC, USDT, Uncorrelated>(
+            &lp_owner,
+            10,
+            907,
+        );
+
+        assert!(coin::balance<BTC>(lp_owner_addr) == 0, 1);
+        assert!(coin::balance<USDT>(lp_owner_addr) == 907, 2);
+
+    }
+    
     #[test]
     public entry fun test_unchecked_swap_can_use_worse_price() {
         let (coin_admin, lp_owner) = register_pool_with_existing_liquidity(101, 10100);


### PR DESCRIPTION
Description:

This PR adds coin registration checks to the `swap`, `swap_into`, and `swap_unchecked` functions within the liquidswap `scripts_v2` module. The code now checks whether the account is registered for the output coin Y before depositing. If the account is not registered, it automatically registers the coin before depositing the swapped `coin_y` into the account. Corresponding tests have been added to ensure functionality.